### PR TITLE
Refactoring base server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ _testmain.go
 
 #Executable
 go-rest-api
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Why not? It's a reasonably simple mathematical conjecture which is easy to imple
 
 It also gives us the potential to examine a few different endpoints, such as `steps` or `values`, if we want to only check the number of steps it takes to get to 1, or which individual values we hit on our way to 1. As such, we can see how we might operate on the same data set with multiple API methods.
 
-We also get the functionality of being able to generate different datasets based on different HTTP methods. For example, if I `GET` a value for `1337`, we can just do the algorithm and return the result down to the client. However, if we `PUSH` to the same endpoint, we can generate a cached copy of the algorithm's output.
+We also get the functionality of being able to generate different datasets based on different HTTP methods. For example, if I `GET` a value for `1337`, we can just do the algorithm and return the result down to the client. However, if we `POST` to the same endpoint, we can generate a cached copy of the algorithm's output.
 
 So, if we request `GET /collatz/1337`, we'll receive a JSON object containing our values and the number of steps:
 
@@ -24,7 +24,7 @@ So, if we request `GET /collatz/1337`, we'll receive a JSON object containing ou
         steps: 44
     }
 
-However, if we `PUSH /collatz/1337`, the server would store the result of the algorithm to a database, and the client would receive a pointer to that entry.
+However, if we `POST /collatz/1337`, the server would store the result of the algorithm to a database, and the client would receive a pointer to that entry.
 
 ## But it doesn't do any of that right now!
 

--- a/rest.go
+++ b/rest.go
@@ -8,16 +8,6 @@ import (
 	"github.com/b4ux1t3/libgollatz"
 )
 
-// RequestNumber doesn't need to exist, I'm just having issues figuring something out
-// Update from future me: So, the problem is that the function ExecuteTemplate is
-// expecting a type with a data interface ,which a primative does not fulfill. There is
-// no good way around this as of right now, except to hardcode the input number into
-// the template.
-//TODO: Get rid of this
-type RequestNumber struct {
-	Num int
-}
-
 var templates = template.Must(template.ParseFiles("result.html", "index.html"))
 
 func collatzHandler(w http.ResponseWriter, r *http.Request) {
@@ -43,9 +33,8 @@ func collatzHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {
-	var num RequestNumber
-	num.Num = 1337
-	err := templates.ExecuteTemplate(w, "index.html", num.Num)
+
+	err := templates.ExecuteTemplate(w, "index.html", nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/rest.go
+++ b/rest.go
@@ -23,10 +23,10 @@ var templates = template.Must(template.ParseFiles("result.html", "index.html"))
 func collatzHandler(w http.ResponseWriter, r *http.Request) {
 	argumentIndex := len("/collatz/")
 	argument, err := strconv.ParseUint(r.URL.Path[argumentIndex:], 10, 64)
-
+	// This executes if we do not receive aninteger from the user after "/collatz/" in the URL path.
 	if err != nil {
-		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
-		//http.Error(w, err.Error(), http.StatusInternalServerError)
+		//http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		http.Error(w, "Unable to parse argument. URL path should be: /collatz/<POSITIVE BASE 10 INTEGER>", http.StatusInternalServerError)
 		return
 	}
 

--- a/rest.go
+++ b/rest.go
@@ -9,6 +9,10 @@ import (
 )
 
 // RequestNumber doesn't need to exist, I'm just having issues figuring something out
+// Update from future me: So, the problem is that the function ExecuteTemplate is
+// expecting a type with a data interface ,which a primative does not fulfill. There is
+// no good way around this as of right now, except to hardcode the input number into
+// the template.
 //TODO: Get rid of this
 type RequestNumber struct {
 	Num int
@@ -28,11 +32,11 @@ func collatzHandler(w http.ResponseWriter, r *http.Request) {
 
 	result := libgollatz.Collatz(argument)
 
-	renderTemplate(w, result)
-}
-
-func renderTemplate(w http.ResponseWriter, r libgollatz.Result) {
-	err := templates.ExecuteTemplate(w, "result.html", r)
+	// This was broken out into a function, but as we are currently only
+	// serving to a browser, there's no reason to break it out. This is
+	// subject to change once we implement a proper REST API. Then, we
+	// can execute this based on seeing a browser user agent.
+	err = templates.ExecuteTemplate(w, "result.html", result)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/rest.go
+++ b/rest.go
@@ -13,23 +13,37 @@ var templates = template.Must(template.ParseFiles("result.html", "index.html"))
 func collatzHandler(w http.ResponseWriter, r *http.Request) {
 	argumentIndex := len("/collatz/")
 	argument, err := strconv.ParseUint(r.URL.Path[argumentIndex:], 10, 64)
-	// This executes if we do not receive aninteger from the user after "/collatz/" in the URL path.
+
+	// This executes if we do not receive an integer from the user after "/collatz/" in the URL path.
 	if err != nil {
 		//http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		http.Error(w, "Unable to parse argument. URL path should be: /collatz/<POSITIVE BASE 10 INTEGER>", http.StatusInternalServerError)
 		return
 	}
 
+	// No matter what, we want to run Collatz on the argument for now.
+	// When we start doing result caching, though, we will want to check
+	// first if we've computed this argument!
 	result := libgollatz.Collatz(argument)
 
-	// This was broken out into a function, but as we are currently only
-	// serving to a browser, there's no reason to break it out. This is
-	// subject to change once we implement a proper REST API. Then, we
-	// can execute this based on seeing a browser user agent.
-	err = templates.ExecuteTemplate(w, "result.html", result)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	// This is the first step toward caching results: we want to switch on
+	// r.Method. Normally, it's not good to put "for now" in comments,
+	// but, for now, we're only going to check for a GET request.
+	switch r.Method {
+	case "GET":
+		// This was broken out into a function, but as we are currently only
+		// serving to a browser, there's no reason to break it out. This is
+		// subject to change once we implement a proper REST API. Then, we
+		// can execute this based on seeing a browser user agent.
+		err = templates.ExecuteTemplate(w, "result.html", result)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+	default:
+		http.Error(w, "Only GET requests allowed right now. Sorry!", http.StatusMethodNotAllowed)
 	}
+
 }
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This was a big step forward.

Now, we're handling requests in a way that let us do things differently if we get different request methods. For the time being, that just means we return a 405 when someone tries to use anything but GET. But this lets us already start to make things a little more modular.

Right now we're still just rendering an HTML page and shipping that out. Next step will be to start delivering JSON instead. Once we do that, we'll be on our way to a fully-functional REST API.